### PR TITLE
Fix up consider_actual_delay unit test

### DIFF
--- a/t/01-base.t
+++ b/t/01-base.t
@@ -57,6 +57,32 @@ subtest "attr: consider_actual_delay" => sub {
 
     $ar = Algorithm::Backoff::Constant->new(
         consider_actual_delay => 1,
+        delay => 2,
+        max_attempts => 0,
+    );
+
+    is($ar->failure(1), 2);
+
+    # we didn't wait, so the delay is now 2+2 = 4
+    is($ar->failure(1), 4);
+
+    # we now waited for 5 seconds, so delay is now 2-1 = 1
+    is($ar->failure(6), 1);
+
+    # we now waited for 2 seconds, so delay is now 2-1 = 1
+    is($ar->failure(8), 1);
+
+    # we now waited for 3 seconds, so delay is now 2-2 = 0
+    is($ar->failure(11), 0);
+};
+
+# This tests that consider_actual_delay uses the post-processed _prev_delay
+# value correctly.
+subtest "attr: consider_actual_delay + post-processing" => sub {
+    my $ar;
+
+    $ar = Algorithm::Backoff::Constant->new(
+        consider_actual_delay => 1,
         delay     => 3,  # "pre-processor" delay
         max_delay => 2,  # real delay
         max_attempts => 0,

--- a/t/01-base.t
+++ b/t/01-base.t
@@ -57,24 +57,25 @@ subtest "attr: consider_actual_delay" => sub {
 
     $ar = Algorithm::Backoff::Constant->new(
         consider_actual_delay => 1,
-        delay     => 3,  # fake "pre-processor" delay
+        delay     => 3,  # "pre-processor" delay
         max_delay => 2,  # real delay
         max_attempts => 0,
     );
 
+    # first failure after 1 second
     is($ar->failure(1), 2);
 
-    # we didn't wait, so the delay is now 2+2 = 4
-    is($ar->failure(1), 4);
+    # 2s delay + instant failure, so the delay is now 3 -> max 2
+    is($ar->failure(1+2+0), 2);
 
-    # we now waited for 5 seconds, so delay is now 2-1 = 1
-    is($ar->failure(6), 1);
+    # 2s delay + 2s failure, so the delay is now 3-2 = 1
+    is($ar->failure(3+2+2), 1);
 
-    # we now waited for 2 seconds, so delay is now 2-1 = 1
-    is($ar->failure(8), 1);
+    # 1s delay + 5s failure, so delay is now 3-5 = -2 -> min 0
+    is($ar->failure(7+1+5), 0);
 
-    # we now waited for 3 seconds, so delay is now 2-2 = 0
-    is($ar->failure(11), 0);
+    # 0s delay + instant failure, so delay is now 3 -> max 2
+    is($ar->failure(13+0+0), 2);
 };
 
 # XXX test jitter_factor for each strategy


### PR DESCRIPTION
Fixes the unit test as discussed on #1.

I didn't want to simulate a user not delaying after the attempt because:

1. It's not realistic for a user choosing to use the algorithm to completely ignore the `$delay` parameter we give them, especially if they are enabling `consider_actual_delay`.
2. It runs into the `max_delay` cap, anyway.

This does test a few different previous delays, though.
